### PR TITLE
Add "remember me"

### DIFF
--- a/server/src/main/java/net/dmcollection/server/AppProperties.java
+++ b/server/src/main/java/net/dmcollection/server/AppProperties.java
@@ -11,7 +11,8 @@ import org.springframework.validation.annotation.Validated;
 public record AppProperties(
     @NotBlank @Nonnull String imageStoragePath,
     @Nonnull CardPage cardPage,
-    @Nonnull String registrationCode) {
+    @Nonnull String registrationCode,
+    @Nonnull String rememberMeKey) {
 
   public record CardPage(@Min(1) int maxSize, @Min(1) int defaultSize) {}
 }

--- a/server/src/main/java/net/dmcollection/server/user/UserService.java
+++ b/server/src/main/java/net/dmcollection/server/user/UserService.java
@@ -1,7 +1,9 @@
 package net.dmcollection.server.user;
 
+import org.springframework.context.annotation.Bean;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.crypto.factory.PasswordEncoderFactories;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -12,9 +14,9 @@ public class UserService implements UserDetailsService {
   private final UserRepository userRepository;
   private final PasswordEncoder passwordEncoder;
 
-  public UserService(UserRepository userRepository, PasswordEncoder passwordEncoder) {
+  public UserService(UserRepository userRepository) {
     this.userRepository = userRepository;
-    this.passwordEncoder = passwordEncoder;
+    this.passwordEncoder = passwordEncoder();
   }
 
   @Override
@@ -38,5 +40,10 @@ public class UserService implements UserDetailsService {
 
   public boolean existsByUsername(String username) {
     return userRepository.findByUsername(username).isPresent();
+  }
+
+  @Bean
+  public PasswordEncoder passwordEncoder() {
+    return PasswordEncoderFactories.createDelegatingPasswordEncoder();
   }
 }

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -19,6 +19,7 @@ dmcollection:
     default-size: 40
     max-size: 100
   registration-code: ${dmcollection_registration_code:}
+  remember-me-key: ${dmcollection_remember_me_key:devkey}
 server:
   servlet:
     session:

--- a/server/src/test/java/net/dmcollection/server/SecurityConfigIntegrationTest.java
+++ b/server/src/test/java/net/dmcollection/server/SecurityConfigIntegrationTest.java
@@ -17,7 +17,7 @@ import org.springframework.test.web.servlet.MockMvc;
 @SpringBootTest
 @AutoConfigureMockMvc
 @ActiveProfiles("test")
-public class SecurityConfigIntegrationTest {
+class SecurityConfigIntegrationTest {
 
   @Autowired private MockMvc mockMvc;
 
@@ -31,12 +31,12 @@ public class SecurityConfigIntegrationTest {
         "/favicon.png",
         "/_app/env.js"
       })
-  public void publicPathsGet(String path) throws Exception {
+  void publicPathsGet(String path) throws Exception {
     mockMvc.perform(get(path)).andExpect(status().isOk());
   }
 
   @Test
-  public void privatePathsGet() throws Exception {
+  void privatePathsGet() throws Exception {
     mockMvc
         .perform(get("/card/dm01-001"))
         .andExpect(status().isOk())
@@ -56,13 +56,13 @@ public class SecurityConfigIntegrationTest {
         "decks/export",
         "cards"
       })
-  public void privateApiPathsGet(String path) throws Exception {
+  void privateApiPathsGet(String path) throws Exception {
     mockMvc.perform(get("/api/" + path)).andExpect(status().isUnauthorized());
   }
 
   @ParameterizedTest
   @ValueSource(strings = {"auth/logout", "decks"})
-  public void privateApiPathsPost(String path) throws Exception {
+  void privateApiPathsPost(String path) throws Exception {
     mockMvc.perform(post("/api/" + path)).andExpect(status().isForbidden());
   }
 }

--- a/ui/src/lib/auth.svelte.ts
+++ b/ui/src/lib/auth.svelte.ts
@@ -39,13 +39,17 @@ interface LoginCredentials {
 	password: string;
 }
 
+interface LoginRequest extends LoginCredentials {
+	rememberMe: boolean;
+}
+
 interface RegistrationRequest extends LoginCredentials {
 	code: string | null;
 }
 
 export async function login(
 	fetch: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>,
-	credentials: LoginCredentials
+	credentials: LoginRequest
 ): Promise<AuthState> {
 	try {
 		const response = await fetch('/api/auth/login', {

--- a/ui/src/lib/components/LoginForm.svelte
+++ b/ui/src/lib/components/LoginForm.svelte
@@ -4,12 +4,13 @@
 
 	let username = '';
 	let password = '';
+	let rememberMe = false;
 	let error = '';
 
 	async function handleSubmit() {
 		error = '';
 
-		const authState = await login(fetch, { username, password });
+		const authState = await login(fetch, { username, password, rememberMe });
 		if (authState.authenticated) {
 			const redirectPath = sessionStorage.getItem('redirectAfterLogin') || '/';
 			sessionStorage.removeItem('redirectAfterLogin');
@@ -56,6 +57,10 @@
 				}}
 			/>
 		</div>
+		<label>
+			<input type="checkbox" bind:checked={rememberMe} />
+			Remember me for 30 days
+		</label>
 	</div>
 
 	{#if error}


### PR DESCRIPTION
Add a checkbox to the login form that allows the user to stay logged in on that browser for 30 days.

The feature is implemented using the simple hash-based token approach.
Since there is no support for changing passwords right now, stolen remember-me cookies cannot be invalidated.

Eventually this should be switched to the persistent-token based approach but that one requires maintaining the token table (deleting expired tokens periodically).