### PR TITLE
Improve name search

### DIFF
--- a/server/src/main/java/net/dmcollection/server/card/internal/query/NameConditionBuilder.java
+++ b/server/src/main/java/net/dmcollection/server/card/internal/query/NameConditionBuilder.java
@@ -1,15 +1,11 @@
 package net.dmcollection.server.card.internal.query;
 
 import static net.dmcollection.server.jooq.generated.tables.Card.CARD;
-import static net.dmcollection.server.jooq.generated.tables.CardSide.CARD_SIDE;
 import static org.jooq.impl.DSL.noCondition;
-import static org.jooq.impl.DSL.selectDistinct;
 
 import org.jooq.Condition;
 
 public class NameConditionBuilder {
-
-  private static final String COMBINED_NAME_SEPARATOR = "／";
 
   private NameConditionBuilder() {}
 
@@ -17,17 +13,10 @@ public class NameConditionBuilder {
     if (nameSearch == null || nameSearch.isEmpty()) {
       return noCondition();
     }
-
-    Condition sideMatch =
-        CARD.ID.in(
-            selectDistinct(CARD_SIDE.CARD_ID)
-                .from(CARD_SIDE)
-                .where(CARD_SIDE.NAME.containsIgnoreCase(nameSearch)));
-
-    if (nameSearch.contains(COMBINED_NAME_SEPARATOR)) {
-      return sideMatch.or(CARD.NAME.containsIgnoreCase(nameSearch));
+    if (nameSearch.startsWith("\"") && nameSearch.endsWith("\"")) {
+      nameSearch = nameSearch.substring(1, nameSearch.length() - 1);
+      return CARD.NAME.equalIgnoreCase(nameSearch);
     }
-
-    return sideMatch;
+    return CARD.NAME.containsIgnoreCase(nameSearch);
   }
 }

--- a/server/src/test/java/net/dmcollection/server/card/CardQueryServiceIntegrationTest.java
+++ b/server/src/test/java/net/dmcollection/server/card/CardQueryServiceIntegrationTest.java
@@ -869,6 +869,23 @@ class CardQueryServiceIntegrationTest extends IntegrationTestBase {
   }
 
   @Test
+  void quotedNameMatchesExactly() {
+    var bolshack = utils.monoCard("ボルシャック・ドラゴン", 6, 6000, FIRE);
+    var neoBolshak = utils.monoCard("ネオ・ボルシャック・ドラゴン", 8, 11000, FIRE);
+    var bolshackCharger =
+        utils.twinpact("ボルシャック・ドラゴン / 決闘者・チャージャー", Set.of(FIRE), Set.of(FIRE), 6, 3, 6000);
+
+    SearchFilter filter = search().setNameSearch("ボルシャック・ドラゴン").build();
+    assertQueryFinds(filter, bolshack, neoBolshak, bolshackCharger);
+
+    filter = search().setNameSearch("\"ボルシャック・ドラゴン\"").build();
+    assertQueryFinds(filter, bolshack);
+
+    filter = search().setNameSearch("\"ボルシャック・ドラゴン / 決闘者・チャージャー\"").build();
+    assertQueryFinds(filter, bolshackCharger);
+  }
+
+  @Test
   void findsCardsByEffectText() {
     var blocker = utils.monoCard("blocker", "ブロッカー");
     var wBreaker = utils.monoCard("double-breaker", "W・ブレイカー");

--- a/server/src/test/java/net/dmcollection/server/carddata/CardDataImportServiceIntegrationTest.java
+++ b/server/src/test/java/net/dmcollection/server/carddata/CardDataImportServiceIntegrationTest.java
@@ -54,9 +54,9 @@ class CardDataImportServiceIntegrationTest extends IntegrationTestBase {
 
   @AfterAll
   void deleteData() {
-    dsl.truncateTable(SET_GROUP).restartIdentity().cascade().execute();
+    dsl.truncateTable(SET_GROUP).cascade().execute();
     dsl.truncateTable(CARD).cascade().execute();
-    dsl.truncateTable(ABILITY).restartIdentity().execute();
+    dsl.truncateTable(ABILITY).cascade().execute();
   }
 
   @Test

--- a/server/src/test/java/net/dmcollection/server/carddata/CardDataImportServiceIntegrationTest.java
+++ b/server/src/test/java/net/dmcollection/server/carddata/CardDataImportServiceIntegrationTest.java
@@ -54,9 +54,9 @@ class CardDataImportServiceIntegrationTest extends IntegrationTestBase {
 
   @AfterAll
   void deleteData() {
-    dsl.truncateTable(SET_GROUP).cascade().execute();
+    dsl.truncateTable(SET_GROUP).restartIdentity().cascade().execute();
     dsl.truncateTable(CARD).cascade().execute();
-    dsl.truncateTable(ABILITY).execute();
+    dsl.truncateTable(ABILITY).restartIdentity().execute();
   }
 
   @Test

--- a/server/src/test/java/net/dmcollection/server/carddata/CardDataImportServiceIntegrationTest.java
+++ b/server/src/test/java/net/dmcollection/server/carddata/CardDataImportServiceIntegrationTest.java
@@ -24,40 +24,16 @@ import java.io.InputStream;
 import java.util.List;
 import java.util.UUID;
 import net.dmcollection.server.IntegrationTestBase;
-import org.jooq.DSLContext;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.flyway.FlywayAutoConfiguration;
-import org.springframework.boot.autoconfigure.jackson.JacksonAutoConfiguration;
-import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
-import org.springframework.boot.autoconfigure.jdbc.DataSourceTransactionManagerAutoConfiguration;
-import org.springframework.boot.autoconfigure.jooq.JooqAutoConfiguration;
-import org.springframework.boot.autoconfigure.transaction.TransactionAutoConfiguration;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.springframework.transaction.annotation.Transactional;
-import org.testcontainers.postgresql.PostgreSQLContainer;
 
-@SpringBootTest(
-    classes = {
-      DataSourceAutoConfiguration.class,
-      DataSourceTransactionManagerAutoConfiguration.class,
-      TransactionAutoConfiguration.class,
-      FlywayAutoConfiguration.class,
-      JooqAutoConfiguration.class,
-      JacksonAutoConfiguration.class,
-      CardDataImportService.class
-    })
-@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @Transactional
-class CardDataImportServiceIntegrationTest {
-
-  @ServiceConnection static final PostgreSQLContainer PG = IntegrationTestBase.PG;
-
-  @Autowired DSLContext dsl;
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class CardDataImportServiceIntegrationTest extends IntegrationTestBase {
 
   @Autowired CardDataImportService importService;
 

--- a/server/src/test/java/net/dmcollection/server/carddata/CardDataImportServiceIntegrationTest.java
+++ b/server/src/test/java/net/dmcollection/server/carddata/CardDataImportServiceIntegrationTest.java
@@ -1,5 +1,6 @@
 package net.dmcollection.server.carddata;
 
+import static net.dmcollection.server.jooq.generated.Tables.ABILITY;
 import static net.dmcollection.server.jooq.generated.Tables.APP_USER;
 import static net.dmcollection.server.jooq.generated.Tables.CARD;
 import static net.dmcollection.server.jooq.generated.Tables.CARD_CIV_GROUP;
@@ -24,6 +25,7 @@ import java.io.InputStream;
 import java.util.List;
 import java.util.UUID;
 import net.dmcollection.server.IntegrationTestBase;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -48,6 +50,13 @@ class CardDataImportServiceIntegrationTest extends IntegrationTestBase {
       data = objectMapper.readValue(is, CardDataJson.class);
     }
     importService.importCardData(data);
+  }
+
+  @AfterAll
+  void deleteData() {
+    dsl.truncateTable(SET_GROUP).cascade().execute();
+    dsl.truncateTable(CARD).cascade().execute();
+    dsl.truncateTable(ABILITY).execute();
   }
 
   @Test

--- a/server/src/test/java/net/dmcollection/server/carddata/CardDataImportServiceIntegrationTest.java
+++ b/server/src/test/java/net/dmcollection/server/carddata/CardDataImportServiceIntegrationTest.java
@@ -38,6 +38,7 @@ import org.springframework.boot.autoconfigure.jooq.JooqAutoConfiguration;
 import org.springframework.boot.autoconfigure.transaction.TransactionAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.transaction.annotation.Transactional;
 import org.testcontainers.postgresql.PostgreSQLContainer;
 
 @SpringBootTest(
@@ -51,6 +52,7 @@ import org.testcontainers.postgresql.PostgreSQLContainer;
       CardDataImportService.class
     })
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@Transactional
 class CardDataImportServiceIntegrationTest {
 
   @ServiceConnection static final PostgreSQLContainer PG = IntegrationTestBase.PG;


### PR DESCRIPTION
- Search the card name (i.e. the combined sides name for twinpacts and multi-sided cards) by default instead of the side names.
- Match the card name exactly when enclosed in quotation marks (`"`).