### PR TITLE
Expose deck zone

### DIFF
--- a/server/src/main/java/net/dmcollection/server/card/CardService.java
+++ b/server/src/main/java/net/dmcollection/server/card/CardService.java
@@ -54,6 +54,7 @@ public class CardService {
       String idText,
       String rarity,
       SetDto set,
+      String zone,
       Set<String> civilizations,
       List<CardFacetDto> facets) {}
 
@@ -129,6 +130,7 @@ public class CardService {
                 PRINTING.ID,
                 PRINTING.OFFICIAL_SITE_ID,
                 PRINTING.COLLECTOR_NUMBER,
+                CARD.DECK_ZONE,
                 CARD_SET.ID,
                 CARD_SET.CODE,
                 CARD_SET.NAME,
@@ -151,6 +153,7 @@ public class CardService {
     String officialSiteId = printingRecord.get(PRINTING.OFFICIAL_SITE_ID);
     String collectorNumber = printingRecord.get(PRINTING.COLLECTOR_NUMBER);
     String rarityName = printingRecord.get(RARITY.NAME);
+    String deckZone = printingRecord.get(CARD.DECK_ZONE);
     SetDto setDto =
         new SetDto(
             printingRecord.get(CARD_SET.ID).longValue(),
@@ -212,6 +215,7 @@ public class CardService {
               null,
               rarityName,
               setDto,
+              deckZone,
               Set.of(),
               null));
     }
@@ -315,6 +319,7 @@ public class CardService {
                 : null,
             rarityName,
             setDto,
+            deckZone,
             allCivilizations,
             facets));
   }

--- a/server/src/main/resources/db/migration/V2__special_zone.sql
+++ b/server/src/main/resources/db/migration/V2__special_zone.sql
@@ -1,0 +1,5 @@
+ALTER TABLE card
+DROP CONSTRAINT card_deck_zone_check;
+
+ALTER TABLE card
+ADD CONSTRAINT card_deck_zone_check CHECK (deck_zone IN ('main', 'hyperspatial', 'gr', 'special'));

--- a/server/src/test/java/net/dmcollection/server/TestFixtureBuilder.java
+++ b/server/src/test/java/net/dmcollection/server/TestFixtureBuilder.java
@@ -501,6 +501,13 @@ public class TestFixtureBuilder {
             .sorted()
             .toArray(Short[]::new);
 
+    String cardZone = "main";
+    if (facetTypes != null) {
+      if (facetTypes.contains(PSYCHIC_CREATURE)) {
+        cardZone = "hyperspatial";
+      }
+    }
+
     // Insert card
     Integer cardId =
         dsl.insertInto(CARD)
@@ -509,6 +516,7 @@ public class TestFixtureBuilder {
             .set(CARD.SORT_COST, sortCost)
             .set(CARD.SORT_POWER, sortPower)
             .set(CARD.SORT_CIVILIZATION, sortCivilization)
+            .set(CARD.DECK_ZONE, cardZone)
             .returningResult(CARD.ID)
             .fetchOne(CARD.ID);
 

--- a/server/src/test/java/net/dmcollection/server/card/CardControllerIntegrationTest.java
+++ b/server/src/test/java/net/dmcollection/server/card/CardControllerIntegrationTest.java
@@ -97,6 +97,16 @@ class CardControllerIntegrationTest extends IntegrationTestBase {
   }
 
   @Test
+  void getCardIncludesDeckZone() throws Exception {
+    var expected = fixtures.createFoursides();
+
+    mockMvc
+        .perform(get("/api/card/" + expected.dmId()).with(user(testUser)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.zone").value("hyperspatial"));
+  }
+
+  @Test
   void getCardReturns404WhenNotFound() throws Exception {
     mockMvc
         .perform(get("/api/card/nonexistent").with(user(testUser)))


### PR DESCRIPTION
- Expose a card's deck zone as `zone` on the `/api/card/<id>` endpoint.
- Support `special` as deck zone value.