### PR TITLE
Gate test data behind profile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ WORKDIR /app
 COPY mvnw pom.xml ./
 COPY .mvn/ .mvn/
 COPY server/pom.xml server/
-RUN ./mvnw -B dependency:go-offline -pl server
+RUN ./mvnw -B dependency:go-offline -DskipTests -pl server
 COPY --from=ui-builder /app/build/ server/src/main/resources/static/
 COPY server/src/ server/src/
 RUN ./mvnw -B package -DskipTests -pl server

--- a/pom.xml
+++ b/pom.xml
@@ -38,16 +38,6 @@
     <testcontainers.version>2.0.5</testcontainers.version>
   </properties>
 
-  <repositories>
-    <repository>
-      <id>github</id>
-      <url>https://maven.pkg.github.com/dm-collection/dmcollection</url>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-    </repository>
-  </repositories>
-
   <dependencyManagement>
     <dependencies>
       <dependency>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -85,13 +85,35 @@
       <artifactId>spring-webflux</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>net.dmcollection</groupId>
-      <artifactId>card-data</artifactId>
-      <version>2.2.0</version>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
+
+  <profiles>
+    <profile>
+      <id>test-fixtures</id>
+      <activation>
+        <property>
+          <name>!skipTests</name>
+        </property>
+      </activation>
+      <repositories>
+        <repository>
+          <id>github</id>
+          <url>https://maven.pkg.github.com/dm-collection/dmcollection</url>
+          <snapshots>
+            <enabled>true</enabled>
+          </snapshots>
+        </repository>
+      </repositories>
+      <dependencies>
+        <dependency>
+          <groupId>net.dmcollection</groupId>
+          <artifactId>card-data</artifactId>
+          <version>2.3.1</version>
+          <scope>test</scope>
+        </dependency>
+      </dependencies>
+    </profile>
+  </profiles>
   <build>
     <plugins>
       <plugin>


### PR DESCRIPTION
Introduce a profile that hides the test data dependency when tests are skipped. This prevents the build from requiring access to the GitHub Maven repo when not running tests.